### PR TITLE
feat: add getTaskById method for individual task retrieval

### DIFF
--- a/.changeset/add-get-task-by-id.md
+++ b/.changeset/add-get-task-by-id.md
@@ -1,0 +1,11 @@
+---
+"sunsama-api": minor
+---
+
+Add getTaskById method for individual task retrieval
+
+- Add `getTaskById(taskId: string)` method to SunsamaClient
+- Supports retrieving any task by its unique ID
+- Returns the complete Task object with all fields or null if not found
+- Includes comprehensive tests and documentation
+- Follows existing patterns for authentication and error handling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ This is a TypeScript package that serves as a wrapper around Sunsama's API. Suns
 - Maintain clean, maintainable, and well-tested code
 - Support full CRUD operations: create, read, update, delete tasks
 - Provide access to archived tasks with pagination support
+- Enable task retrieval by ID for individual task operations
 - Action item checklist and MVP requirements are documented in MVP_AUTH.md
 
 ## Development Environment

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ const backlog = await client.getTasksBacklog();
 // Get archived tasks with pagination
 const archivedTasks = await client.getArchivedTasks();
 const moreArchived = await client.getArchivedTasks(100, 50); // offset 100, limit 50
+
+// Get a specific task by ID
+const task = await client.getTaskById('685022edbdef77163d659d4a');
+if (task) {
+  console.log('Found task:', task.text);
+  console.log('Task completed:', task.completed);
+  console.log('Time estimate:', task.timeEstimate, 'minutes');
+} else {
+  console.log('Task not found');
+}
 ```
 
 #### Creating Tasks

--- a/scripts/test-real-auth.ts
+++ b/scripts/test-real-auth.ts
@@ -186,6 +186,54 @@ async function testRealAuth() {
       console.log('   No streams found for group');
     }
 
+    // Test getTaskById method with existing tasks
+    console.log('\n🔍 Testing getTaskById method...');
+
+    let testTaskId: string | undefined;
+
+    // Try to get an existing task ID from our task lists
+    if (allTasks.length > 0) {
+      testTaskId = allTasks[0]!._id;
+      console.log(`   Testing with existing task ID: ${testTaskId}`);
+
+      const existingTask = await client.getTaskById(testTaskId);
+
+      if (existingTask) {
+        console.log('✅ getTaskById successful!');
+        console.log('\n📊 Retrieved Task Information:');
+        console.log(`   Task ID: ${existingTask._id}`);
+        console.log(`   Text: ${existingTask.text}`);
+        console.log(`   Completed: ${existingTask.completed}`);
+        console.log(`   Created: ${existingTask.createdAt}`);
+        console.log(`   Last Modified: ${existingTask.lastModified}`);
+        console.log(`   Time Estimate: ${existingTask.timeEstimate || 'N/A'} minutes`);
+        console.log(`   Subtasks: ${existingTask.subtasks.length}`);
+        console.log(`   Comments: ${existingTask.comments.length}`);
+        if (existingTask.integration) {
+          console.log(`   Integration: ${existingTask.integration.service}`);
+        }
+        if (existingTask.snooze) {
+          console.log(`   Snooze until: ${existingTask.snooze.until}`);
+        }
+        console.log(`   Stream IDs: ${existingTask.streamIds.join(', ') || 'None'}`);
+      } else {
+        console.log('⚠️ Task not found (returned null)');
+      }
+    } else {
+      console.log('   No existing tasks found to test with');
+    }
+
+    // Test with a non-existent task ID
+    console.log('\n   Testing with non-existent task ID...');
+    const nonExistentTaskId = '507f1f77bcf86cd799439999';
+    const nonExistentTask = await client.getTaskById(nonExistentTaskId);
+
+    if (nonExistentTask === null) {
+      console.log('✅ getTaskById correctly returned null for non-existent task');
+    } else {
+      console.log('⚠️ Unexpected: getTaskById returned a task for non-existent ID');
+    }
+
     // Test createTask method with custom ID (for tracking through completion and deletion)
     console.log('\n✨ Testing createTask method...');
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -215,6 +263,32 @@ async function testRealAuth() {
       console.log(
         `   Time Estimate: ${createdTask.updatedFields.recommendedTimeEstimate || 'None'} minutes`
       );
+    }
+
+    // Test getTaskById with the newly created task
+    console.log('\n🔍 Testing getTaskById with newly created task...');
+    console.log(`   Retrieving task: ${taskId}`);
+    const retrievedTask = await client.getTaskById(taskId);
+
+    if (retrievedTask) {
+      console.log('✅ getTaskById successful for created task!');
+      console.log('\n📊 Retrieved Created Task Information:');
+      console.log(`   Task ID: ${retrievedTask._id}`);
+      console.log(`   Text: ${retrievedTask.text}`);
+      console.log(`   Notes: ${retrievedTask.notes || 'None'}`);
+      console.log(`   Completed: ${retrievedTask.completed}`);
+      console.log(`   Time Estimate: ${retrievedTask.timeEstimate || 'N/A'} minutes`);
+      console.log(`   Stream IDs: ${retrievedTask.streamIds.join(', ') || 'None'}`);
+      console.log(`   Created: ${retrievedTask.createdAt}`);
+
+      // Verify the task matches what we created
+      if (retrievedTask.text === taskText) {
+        console.log('✅ Task text matches what we created');
+      } else {
+        console.log('⚠️ Task text does not match what we created');
+      }
+    } else {
+      console.log('❌ Failed to retrieve newly created task');
     }
 
     // Test updateTaskSnoozeDate method (unified scheduling operations)

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -294,5 +294,36 @@ describe('SunsamaClient', () => {
       await expect(promise1).rejects.toThrow('GraphQL errors: Unauthorized');
       await expect(promise2).rejects.toThrow('GraphQL errors: Unauthorized');
     });
+
+    it('should have getTaskById method', () => {
+      const client = new SunsamaClient();
+
+      expect(typeof client.getTaskById).toBe('function');
+    });
+
+    it('should throw error when calling getTaskById without authentication', async () => {
+      const client = new SunsamaClient();
+
+      // Should fail because no authentication
+      await expect(client.getTaskById('test-task-id')).rejects.toThrow();
+    });
+
+    it('should accept valid task ID in getTaskById', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(client.getTaskById(validTaskId)).rejects.toThrow('GraphQL errors: Unauthorized');
+    });
+
+    it('should handle task not found in getTaskById', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const nonExistentTaskId = '507f1f77bcf86cd799439999';
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(client.getTaskById(nonExistentTaskId)).rejects.toThrow(
+        'GraphQL errors: Unauthorized'
+      );
+    });
   });
 });

--- a/src/queries/tasks.ts
+++ b/src/queries/tasks.ts
@@ -60,3 +60,20 @@ export const GET_ARCHIVED_TASKS_QUERY = gql`
 
   ${TASK_INTEGRATION_FRAGMENT}
 `;
+
+export const GET_TASK_BY_ID_QUERY = gql`
+  query getTaskById($taskId: String!, $groupId: String!) {
+    taskById(taskId: $taskId, groupId: $groupId) {
+      ...Task
+      __typename
+    }
+  }
+
+  ${TASK_FRAGMENT}
+
+  ${TASK_ACTUAL_TIME_FRAGMENT}
+
+  ${TASK_SCHEDULED_TIME_FRAGMENT}
+
+  ${TASK_INTEGRATION_FRAGMENT}
+`;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1263,3 +1263,20 @@ export interface GetArchivedTasksInput {
 export interface GetArchivedTasksResponse {
   archivedTasks: Task[];
 }
+
+/**
+ * Input for getTaskById query
+ */
+export interface GetTaskByIdInput {
+  /** The ID of the task to retrieve */
+  taskId: string;
+  /** Group ID that the task belongs to */
+  groupId: string;
+}
+
+/**
+ * Response for getTaskById query
+ */
+export interface GetTaskByIdResponse {
+  taskById: Task | null;
+}


### PR DESCRIPTION
## Summary
- Add `getTaskById(taskId: string)` method to SunsamaClient for retrieving individual tasks
- Returns complete Task object with all fields or null if not found  
- Follows existing authentication and error handling patterns
- Includes comprehensive tests and documentation

## Implementation Details
- Added GET_TASK_BY_ID_QUERY GraphQL query using existing Task fragment
- Added GetTaskByIdInput and GetTaskByIdResponse TypeScript interfaces  
- Implemented client method with proper groupId validation
- Added unit tests covering method existence, authentication, and edge cases
- Enhanced integration test script to verify functionality with real API
- Updated README.md with usage examples

## Test plan
- [x] Unit tests pass (`npm run test`)
- [x] Integration tests pass (`npm run test:auth`) 
- [x] Method retrieves existing tasks successfully
- [x] Method returns null for non-existent tasks
- [x] Method throws appropriate errors for unauthenticated requests
- [x] Documentation updated with examples
- [x] Changeset created for version bump

## Breaking Changes
None - this is a purely additive change that maintains backward compatibility.

## Usage Example
```typescript
// Get a task by ID
const task = await client.getTaskById('685022edbdef77163d659d4a');

if (task) {
  console.log('Found task:', task.text);
  console.log('Task completed:', task.completed);
  console.log('Time estimate:', task.timeEstimate, 'minutes');
} else {
  console.log('Task not found');
}
```