### PR TITLE
fix: update TypeScript configuration for proper type generation

### DIFF
--- a/.changeset/fix-typescript-configuration.md
+++ b/.changeset/fix-typescript-configuration.md
@@ -1,0 +1,7 @@
+---
+"sunsama-api": patch
+---
+
+Fix TypeScript configuration for proper type generation
+
+Updates tsconfig.json to ensure correct type declaration file generation and build output structure.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,6 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*", "scripts/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "scripts"]
 }


### PR DESCRIPTION
## Summary
- Fixed TypeScript configuration in `tsconfig.json` to exclude scripts from compilation
- Added changeset file for proper version tracking

## Changes
- Updated `tsconfig.json` to only include `src/**/*` and exclude `scripts` directory
- This ensures proper type declaration file generation and build output structure

## Test plan
- [x] Verify TypeScript compilation works correctly
- [x] Check that type definitions are generated properly
- [x] Ensure build output structure is correct