### PR TITLE
Add updateTaskText method for task title management

### DIFF
--- a/.changeset/add-update-task-text.md
+++ b/.changeset/add-update-task-text.md
@@ -1,0 +1,15 @@
+---
+"sunsama-api": minor
+---
+
+Add updateTaskText method for updating task titles
+
+Adds a new `updateTaskText` method that allows updating the text/title of a task. This method supports optional parameters for setting recommended stream IDs and controlling response payload size. The implementation includes comprehensive TypeScript types, GraphQL mutations, unit tests, and integration tests.
+
+Features:
+- Update task text/title with simple API
+- Optional recommended stream ID parameter  
+- Support for limiting response payload
+- Full TypeScript type safety
+- Comprehensive test coverage
+- Integration with existing GraphQL patterns

--- a/README.md
+++ b/README.md
@@ -231,6 +231,36 @@ const deleteResultFull = await client.deleteTask('taskId', false);
 const deleteResultMerged = await client.deleteTask('taskId', true, true);
 ```
 
+#### Updating Task Text/Title
+
+You can update the text or title of a task using the `updateTaskText` method. This method allows you to change the main title/description of a task and optionally set a recommended stream ID.
+
+```typescript
+// Update task text to a new title
+const result = await client.updateTaskText('taskId123', 'Updated task title');
+
+// Update with recommended stream ID
+const result = await client.updateTaskText('taskId123', 'Task with stream', {
+  recommendedStreamId: 'stream-id-123'
+});
+
+// Get full response payload instead of limited response
+const result = await client.updateTaskText('taskId123', 'New title', {
+  limitResponsePayload: false
+});
+
+// Clear recommended stream ID
+const result = await client.updateTaskText('taskId123', 'Task without stream', {
+  recommendedStreamId: null
+});
+
+// Combine all options
+const result = await client.updateTaskText('taskId123', 'Full options task', {
+  recommendedStreamId: 'stream-456',
+  limitResponsePayload: false
+});
+```
+
 #### Updating Task Planned Time
 
 You can update the time estimate (planned time) for a task using the `updateTaskPlannedTime` method. The time estimate represents how long you expect the task to take and is specified in minutes.

--- a/scripts/test-real-auth.ts
+++ b/scripts/test-real-auth.ts
@@ -490,7 +490,7 @@ async function testRealAuth() {
     futureDate.setDate(futureDate.getDate() + 7); // 7 days from now
     const futureDateString = futureDate.toISOString();
     console.log(`   Setting due date to: ${futureDateString}`);
-    
+
     const dueDateResult = await client.updateTaskDueDate(taskId, futureDate);
 
     console.log('✅ updateTaskDueDate successful!');
@@ -565,6 +565,76 @@ async function testRealAuth() {
       }
     } else {
       console.log('❌ Failed to retrieve task after clearing due date');
+    }
+
+    // Test updateTaskText method
+    console.log('\\n📝 Testing updateTaskText method...');
+    const originalTaskText = retrievedTask?.text || taskText;
+    const textTimestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const newTaskText = `Updated task title - ${textTimestamp}`;
+
+    console.log(`   Original text: ${originalTaskText}`);
+    console.log(`   New text: ${newTaskText}`);
+    console.log(`   Updating text for task: ${taskId}`);
+
+    const textUpdateResult = await client.updateTaskText(taskId, newTaskText);
+
+    console.log('✅ updateTaskText successful!');
+    console.log('\\n📊 Task Text Update Information:');
+    console.log(`   Success: ${textUpdateResult.success}`);
+    console.log(`   Skipped: ${textUpdateResult.skipped || false}`);
+    if (textUpdateResult.updatedFields) {
+      console.log(`   Task ID: ${textUpdateResult.updatedFields._id}`);
+      console.log(
+        `   Stream IDs: ${textUpdateResult.updatedFields.streamIds?.join(', ') || 'None'}`
+      );
+    } else {
+      console.log('   updatedFields: null (limitResponsePayload=true)');
+    }
+
+    // Test updateTaskText with options
+    console.log('\\n   Testing updateTaskText with options...');
+    const textWithOptionsResult = await client.updateTaskText(
+      taskId,
+      `Task with options - ${textTimestamp}`,
+      {
+        recommendedStreamId: streams.length > 0 ? streams[0]!._id : null,
+        limitResponsePayload: false,
+      }
+    );
+
+    console.log('✅ updateTaskText with options successful!');
+    console.log('📊 Task Text Update with Options Information:');
+    console.log(`   Success: ${textWithOptionsResult.success}`);
+    console.log(`   Skipped: ${textWithOptionsResult.skipped || false}`);
+    if (textWithOptionsResult.updatedFields) {
+      console.log(`   Task ID: ${textWithOptionsResult.updatedFields._id}`);
+      console.log(
+        `   Recommended Stream: ${textWithOptionsResult.updatedFields.recommendedStreamId || 'None'}`
+      );
+      console.log(
+        `   Stream IDs: ${textWithOptionsResult.updatedFields.streamIds?.join(', ') || 'None'}`
+      );
+    } else {
+      console.log('   updatedFields: null');
+    }
+
+    // Verify the text was updated by retrieving the task
+    console.log('\\n🔍 Verifying text update by retrieving task...');
+    const taskAfterTextUpdate = await client.getTaskById(taskId);
+    if (taskAfterTextUpdate) {
+      console.log('✅ Task retrieved successfully after text update');
+      console.log(`   Current text: ${taskAfterTextUpdate.text}`);
+      console.log(`   Original text: ${originalTaskText}`);
+
+      // Check if text was actually updated
+      if (taskAfterTextUpdate.text.includes(textTimestamp)) {
+        console.log('✅ Text was successfully updated with timestamp');
+      } else {
+        console.log('⚠️ Text may not have been updated or timestamp not found');
+      }
+    } else {
+      console.log('❌ Failed to retrieve task after text update');
     }
 
     // Test updateTaskComplete method

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -585,5 +585,111 @@ describe('SunsamaClient', () => {
         client.updateTaskNotes(validTaskId, { markdown: markdownNotes })
       ).rejects.toThrow('GraphQL errors: Unauthorized');
     });
+
+    it('should have updateTaskText method', () => {
+      const client = new SunsamaClient();
+
+      expect(typeof client.updateTaskText).toBe('function');
+    });
+
+    it('should throw error when calling updateTaskText without authentication', async () => {
+      const client = new SunsamaClient();
+
+      // Should fail because no authentication
+      await expect(client.updateTaskText('test-task-id', 'New task title')).rejects.toThrow();
+    });
+
+    it('should accept valid parameters in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(client.updateTaskText(validTaskId, 'Updated task title')).rejects.toThrow(
+        'GraphQL errors: Unauthorized'
+      );
+    });
+
+    it('should accept recommendedStreamId option in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(
+        client.updateTaskText(validTaskId, 'Task with stream', {
+          recommendedStreamId: 'stream-id-123',
+        })
+      ).rejects.toThrow('GraphQL errors: Unauthorized');
+    });
+
+    it('should support limitResponsePayload option in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+
+      // Should pass validation with limitResponsePayload option
+      // Will fail at GraphQL level due to unauthorized access
+      await expect(
+        client.updateTaskText(validTaskId, 'New title', {
+          limitResponsePayload: false,
+        })
+      ).rejects.toThrow('GraphQL errors: Unauthorized');
+    });
+
+    it('should handle empty text in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+
+      // Should pass validation even with empty text but fail at GraphQL level (unauthorized)
+      await expect(client.updateTaskText(validTaskId, '')).rejects.toThrow(
+        'GraphQL errors: Unauthorized'
+      );
+    });
+
+    it('should handle special characters in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+      const specialText = 'Task with émojis 🚀 and special chars: @#$%^&*()';
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(client.updateTaskText(validTaskId, specialText)).rejects.toThrow(
+        'GraphQL errors: Unauthorized'
+      );
+    });
+
+    it('should handle long text in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+      const longText = 'A'.repeat(1000); // 1000 character text
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(client.updateTaskText(validTaskId, longText)).rejects.toThrow(
+        'GraphQL errors: Unauthorized'
+      );
+    });
+
+    it('should handle null recommendedStreamId in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(
+        client.updateTaskText(validTaskId, 'Task with null stream', {
+          recommendedStreamId: null,
+        })
+      ).rejects.toThrow('GraphQL errors: Unauthorized');
+    });
+
+    it('should combine all options in updateTaskText', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+      const validTaskId = '685022edbdef77163d659d4a';
+
+      // Should pass validation with all options combined
+      // Will fail at GraphQL level due to unauthorized access
+      await expect(
+        client.updateTaskText(validTaskId, 'Combined options task', {
+          recommendedStreamId: 'stream-123',
+          limitResponsePayload: false,
+        })
+      ).rejects.toThrow('GraphQL errors: Unauthorized');
+    });
   });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -22,6 +22,7 @@ import {
   UPDATE_TASK_PLANNED_TIME_MUTATION,
   UPDATE_TASK_SNOOZE_DATE_MUTATION,
   UPDATE_TASK_DUE_DATE_MUTATION,
+  UPDATE_TASK_TEXT_MUTATION,
 } from '../queries/index.js';
 import type {
   CollabSnapshot,
@@ -56,6 +57,7 @@ import type {
   UpdateTaskPlannedTimeInput,
   UpdateTaskSnoozeDateInput,
   UpdateTaskDueDateInput,
+  UpdateTaskTextInput,
   User,
 } from '../types/index.js';
 import {
@@ -1242,6 +1244,66 @@ export class SunsamaClient {
     }
 
     return (response.data as { updateTaskDueDate: UpdateTaskPayload }).updateTaskDueDate;
+  }
+
+  /**
+   * Updates the text/title of a task
+   *
+   * This method allows you to update the main text or title of a task. You can optionally
+   * specify a recommended stream ID for the task.
+   *
+   * @param taskId - The ID of the task to update
+   * @param text - The new text/title for the task
+   * @param options - Additional options for the operation
+   * @returns The update result with success status
+   * @throws SunsamaAuthError if not authenticated or request fails
+   *
+   * @example
+   * ```typescript
+   * // Update task text to a new title
+   * const result = await client.updateTaskText('taskId123', 'Updated task title');
+   *
+   * // Update with recommended stream ID
+   * const result = await client.updateTaskText('taskId123', 'Task with stream', {
+   *   recommendedStreamId: 'stream-id-123'
+   * });
+   *
+   * // Get full response payload instead of limited response
+   * const result = await client.updateTaskText('taskId123', 'New title', {
+   *   limitResponsePayload: false
+   * });
+   * ```
+   */
+  async updateTaskText(
+    taskId: string,
+    text: string,
+    options?: {
+      recommendedStreamId?: string | null;
+      limitResponsePayload?: boolean;
+    }
+  ): Promise<UpdateTaskPayload> {
+    const variables: { input: UpdateTaskTextInput } = {
+      input: {
+        taskId,
+        text,
+        recommendedStreamId: options?.recommendedStreamId || null,
+        limitResponsePayload: options?.limitResponsePayload ?? true,
+      },
+    };
+
+    const request: GraphQLRequest = {
+      operationName: 'updateTaskText',
+      variables,
+      query: UPDATE_TASK_TEXT_MUTATION,
+    };
+
+    const response = await this.graphqlRequest(request);
+
+    if (!response.data) {
+      throw new SunsamaAuthError('No response data received');
+    }
+
+    return (response.data as { updateTaskText: UpdateTaskPayload }).updateTaskText;
   }
 
   /**

--- a/src/queries/mutations/index.ts
+++ b/src/queries/mutations/index.ts
@@ -9,3 +9,4 @@ export * from './updateTaskSnoozeDate.js';
 export * from './updateTaskNotes.js';
 export * from './updateTaskPlannedTime.js';
 export * from './updateTaskDueDate.js';
+export * from './updateTaskText.js';

--- a/src/queries/mutations/updateTaskText.ts
+++ b/src/queries/mutations/updateTaskText.ts
@@ -1,0 +1,552 @@
+/**
+ * GraphQL mutation for updating task text/title
+ */
+
+import { gql } from 'graphql-tag';
+
+export const UPDATE_TASK_TEXT_MUTATION = gql`
+  mutation updateTaskText($input: UpdateTaskTextInput!) {
+    updateTaskText(input: $input) {
+      ...UpdateTaskPayload
+      __typename
+    }
+  }
+
+  fragment UpdateTaskPayload on UpdateTaskPayload {
+    updatedTask {
+      ...Task
+      __typename
+    }
+    updatedFields {
+      ...PartialTask
+      __typename
+    }
+    success
+    skipped
+    __typename
+  }
+
+  fragment Task on Task {
+    _id
+    groupId
+    taskType
+    streamIds
+    recommendedStreamId
+    eventInfo {
+      eventId
+      clone
+      __typename
+    }
+    seededEventIds
+    private
+    assigneeId
+    createdBy
+    integration {
+      ...TaskIntegration
+      __typename
+    }
+    deleted
+    text
+    notes
+    notesMarkdown
+    notesChecksum
+    editorVersion
+    collabSnapshot
+    completed
+    completedBy
+    completeDate
+    completeOn
+    archivedAt
+    duration
+    runDate {
+      startDate
+      endDate
+      __typename
+    }
+    snooze {
+      userId
+      date
+      until
+      __typename
+    }
+    timeHorizon {
+      type
+      relativeTo
+      __typename
+    }
+    dueDate
+    comments {
+      userId
+      text
+      markdown
+      editorVersion
+      groupId
+      createdAt
+      editedAt
+      deleted
+      file
+      fileMetadata {
+        url
+        filename
+        mimetype
+        size
+        width
+        height
+        __typename
+      }
+      __typename
+    }
+    orderings {
+      ordinal
+      panelDate
+      channelId
+      userId
+      __typename
+    }
+    backlogOrderings {
+      horizonType
+      position
+      streamId
+      __typename
+    }
+    subtasks {
+      _id
+      title
+      completedDate
+      completedBy
+      timeEstimate
+      actualTime {
+        ...TaskActualTime
+        __typename
+      }
+      snooze {
+        userId
+        date
+        until
+        __typename
+      }
+      scheduledTime {
+        ...TaskScheduledTime
+        __typename
+      }
+      integration {
+        ...TaskIntegration
+        __typename
+      }
+      mergedTaskId
+      recommendedTimeEstimate
+      __typename
+    }
+    subtasksCollapsed
+    sequence {
+      date
+      id
+      expiresDate
+      ruleString
+      searchable
+      forked
+      final
+      estimatedStart {
+        hour
+        minute
+        __typename
+      }
+      master
+      finalDate
+      template {
+        streamIds
+        private
+        text
+        notes
+        notesMarkdown
+        notesChecksum
+        editorVersion
+        subtasks {
+          _id
+          title
+          completedDate
+          completedBy
+          timeEstimate
+          actualTime {
+            ...TaskActualTime
+            __typename
+          }
+          __typename
+        }
+        timeEstimate
+        assigneeId
+        __typename
+      }
+      __typename
+    }
+    followers
+    recommendedTimeEstimate
+    timeEstimate
+    actualTime {
+      ...TaskActualTime
+      __typename
+    }
+    scheduledTime {
+      ...TaskScheduledTime
+      __typename
+    }
+    createdAt
+    lastModified
+    objectiveId
+    ritual {
+      id
+      period {
+        interval
+        startCalendarDay
+        endCalendarDay
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+
+  fragment TaskActualTime on TaskActualTime {
+    userId
+    startDate
+    endDate
+    duration
+    isTimerEntry
+    __typename
+  }
+
+  fragment TaskScheduledTime on TaskScheduledTime {
+    eventId
+    serviceIds {
+      google
+      microsoft
+      microsoftUniqueId
+      apple
+      appleRecurrenceId
+      sunsama
+      __typename
+    }
+    calendarId
+    userId
+    startDate
+    endDate
+    isAllDay
+    importedFromCalendar
+    __typename
+  }
+
+  fragment TaskIntegration on TaskIntegration {
+    ... on TaskAsanaIntegration {
+      service
+      identifier {
+        id
+        url
+        accountId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskTrelloIntegration {
+      service
+      identifier {
+        id
+        url
+        accountId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskJiraIntegration {
+      service
+      identifier {
+        id
+        cloudId
+        accountId
+        url
+        __typename
+      }
+      __typename
+    }
+    ... on TaskGithubIntegration {
+      service
+      identifier {
+        id
+        repositoryOwnerLogin
+        repositoryName
+        number
+        type
+        url
+        __typename
+      }
+      __typename
+    }
+    ... on TaskTodoistIntegration {
+      service
+      identifier {
+        id
+        url
+        deepUrl
+        __typename
+      }
+      __typename
+    }
+    ... on TaskGoogleCalendarIntegration {
+      service
+      identifier {
+        sunsamaId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskOutlookCalendarIntegration {
+      service
+      identifier {
+        sunsamaId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskAppleCalendarIntegration {
+      service
+      identifier {
+        sunsamaId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskSunsamaCalendarIntegration {
+      service
+      identifier {
+        sunsamaId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskGmailIntegration {
+      service
+      identifier {
+        id
+        messageId
+        accountId
+        url
+        __typename
+      }
+      __typename
+    }
+    ... on TaskOutlookIntegration {
+      service
+      identifier {
+        id
+        internetMessageId
+        conversationId
+        accountId
+        url
+        __typename
+      }
+      __typename
+    }
+    ... on TaskSlackIntegration {
+      service
+      identifier {
+        permalink
+        notesMarkdown
+        __typename
+      }
+      __typename
+    }
+    ... on TaskNotionIntegration {
+      service
+      identifier {
+        id
+        workspaceId
+        url
+        deepUrl
+        __typename
+      }
+      __typename
+    }
+    ... on TaskClickUpIntegration {
+      service
+      identifier {
+        id
+        userId
+        teamId
+        url
+        __typename
+      }
+      __typename
+    }
+    ... on TaskGitlabIntegration {
+      service
+      identifier {
+        id
+        __typename
+      }
+      __typename
+    }
+    ... on TaskEmailIntegration {
+      service
+      identifier {
+        id
+        __typename
+      }
+      content {
+        subject
+        text
+        html
+        from {
+          name
+          email
+          __typename
+        }
+        date
+        __typename
+      }
+      __typename
+    }
+    ... on TaskLinearIntegration {
+      service
+      identifier {
+        id
+        url
+        identifier
+        linearUserId
+        linearOrganizationId
+        number
+        _version
+        __typename
+      }
+      __typename
+    }
+    ... on TaskMondayIntegration {
+      service
+      identifier {
+        id
+        boardId
+        mondayAccountId
+        url
+        __typename
+      }
+      __typename
+    }
+    ... on TaskWebsiteIntegration {
+      service
+      identifier {
+        url
+        private
+        canonicalUrl
+        description
+        faviconUrl
+        imageUrl
+        siteName
+        title
+        __typename
+      }
+      __typename
+    }
+    ... on TaskLoomVideoIntegration {
+      service
+      identifier {
+        url
+        videoId
+        title
+        description
+        thumbnail {
+          width
+          height
+          url
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    ... on TaskMicrosoftTeamsIntegration {
+      service
+      identifier {
+        permalink
+        notesMarkdown
+        __typename
+      }
+      __typename
+    }
+    ... on TaskAppleRemindersIntegration {
+      service
+      identifier {
+        id
+        listId
+        autoImported
+        __typename
+      }
+      __typename
+    }
+    ... on TaskGoogleTasksIntegration {
+      service
+      identifier {
+        id
+        listId
+        accountId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskMicrosoftToDoIntegration {
+      service
+      identifier {
+        id
+        listId
+        accountId
+        parentTaskId
+        __typename
+      }
+      __typename
+    }
+    ... on TaskSunsamaTaskIntegration {
+      service
+      identifier {
+        taskId
+        groupId
+        sunsamaUserId
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+
+  fragment PartialTask on PartialTask {
+    _id
+    recommendedStreamId
+    streamIds
+    recommendedTimeEstimate
+    subtasks {
+      _id
+      title
+      completedDate
+      completedBy
+      timeEstimate
+      actualTime {
+        ...TaskActualTime
+        __typename
+      }
+      snooze {
+        userId
+        date
+        until
+        __typename
+      }
+      scheduledTime {
+        ...TaskScheduledTime
+        __typename
+      }
+      integration {
+        ...TaskIntegration
+        __typename
+      }
+      mergedTaskId
+      recommendedTimeEstimate
+      __typename
+    }
+    __typename
+  }
+`;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1356,3 +1356,20 @@ export interface UpdateTaskDueDateInput {
   /** Flag to limit response payload (returns null for updatedTask and updatedFields when true) */
   limitResponsePayload?: boolean;
 }
+
+/**
+ * Input for updateTaskText mutation
+ */
+export interface UpdateTaskTextInput {
+  /** The ID of the task to update */
+  taskId: string;
+
+  /** The new text/title for the task */
+  text: string;
+
+  /** Recommended stream ID (optional) */
+  recommendedStreamId?: string | null;
+
+  /** Flag to limit response payload (returns null for updatedTask and updatedFields when true) */
+  limitResponsePayload?: boolean;
+}


### PR DESCRIPTION
## Summary
- Adds new `updateTaskText` method to the Sunsama API client
- Allows updating task titles/text with optional stream recommendations
- Includes comprehensive TypeScript types and GraphQL mutations
- Full test coverage with unit and integration tests

## Features
- Update task text/title with simple API: `client.updateTaskText(taskId, newText)`
- Optional `recommendedStreamId` parameter for stream assignment
- Support for `limitResponsePayload` option to control response size
- Full TypeScript type safety with proper interfaces
- Follows established GraphQL patterns and client conventions

## Test Coverage
- ✅ Unit tests covering all method variations and edge cases
- ✅ Integration tests with real API endpoints
- ✅ Proper error handling validation
- ✅ All existing tests continue to pass

## Documentation
- Updated README.md with comprehensive usage examples
- Added JSDoc documentation with detailed examples
- Changeset included for proper version management

## Test Results
```
 Test Files  5 passed (5)
      Tests  146 passed (146) 
```

Integration tests also passed successfully with real API calls.