### PR TITLE
fix: reorderTask error classes, ordinal calc, tests, and docs

### DIFF
--- a/.changeset/fix-reorder-task-followup.md
+++ b/.changeset/fix-reorder-task-followup.md
@@ -1,0 +1,11 @@
+---
+"sunsama-api": patch
+---
+
+fix: correct error classes and ordinal calculation in reorderTask
+
+- Use `SunsamaValidationError` for invalid date format and position errors
+- Use `SunsamaError` for task-not-found and missing response data
+- Fix `calculateOrdinal` to avoid negative ordinals when moving a task to the top of a list with small ordinal values
+- Add integration tests for `reorderTask`
+- Add `reorderTask` documentation to README

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,15 @@ src/
 - Type-safe query/mutation functions with gql-tag
 
 ### Error Handling
-- Custom error hierarchy: `SunsamaError` → `SunsamaAuthError` / `SunsamaApiError`
+- Custom error hierarchy: `SunsamaError` → `SunsamaAuthError` / `SunsamaApiError` / `SunsamaValidationError`
 - Always throw errors, never return error objects
 - Include context in error messages
+- Use the right subclass:
+  - `SunsamaAuthError` — authentication failures only (login failed, session expired, cannot determine user ID)
+  - `SunsamaApiError` — API-level failures with HTTP status (use the existing throw sites in `graphqlRequest` as the primary source)
+  - `SunsamaValidationError` — invalid caller input (bad format, out-of-range values); accepts optional `field` parameter
+  - `SunsamaError` — generic errors that don't fit a more specific class (e.g. missing response data)
+  - **Never** use `SunsamaAuthError` for validation errors or data-not-found conditions
 
 ### Type Safety
 - Strict TypeScript configuration
@@ -185,6 +191,7 @@ describe.skipIf(!hasCredentials())('Feature Name (Integration)', () => {
 
 - **Branch naming**: `{type}/{short-name}` (e.g., `feat/add-subtasks`, `fix/auth-bug`)
 - **Commit email**: Use GitHub no-reply for this project
+- **Merge strategy**: Use rebase merge (`gh pr merge --rebase`) — not squash or merge commit
 
 ## Key Areas of Focus
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,28 @@ const deleteResultFull = await client.deleteTask('taskId', false);
 const deleteResultMerged = await client.deleteTask('taskId', true, true);
 ```
 
+#### Reordering Tasks
+
+Move a task to a specific position within a day using the `reorderTask` method. Positions are 0-based (0 = top of the list).
+
+```typescript
+// Move a task to the top of today's list
+const result = await client.reorderTask('taskId123', 0, '2026-01-12');
+
+// Move a task to the second position
+const result = await client.reorderTask('taskId123', 1, '2026-01-12');
+
+// Move a task to position 3 (fourth from top)
+const result = await client.reorderTask('taskId123', 3, '2026-01-12');
+
+// With explicit timezone
+const result = await client.reorderTask('taskId123', 0, '2026-01-12', {
+  timezone: 'America/New_York',
+});
+
+console.log(result.updatedTaskIds); // Array of task IDs affected by the reorder
+```
+
 #### Updating Task Text/Title
 
 You can update the text or title of a task using the `updateTaskText` method. This method allows you to change the main title/description of a task and optionally set a recommended stream ID.

--- a/src/__tests__/integration/tasks-reordering.test.ts
+++ b/src/__tests__/integration/tasks-reordering.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Integration tests for task reordering operations
+ */
+
+import 'dotenv/config';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { SunsamaClient } from '../../client/index.js';
+import { getAuthenticatedClient, hasCredentials, trackTaskForCleanup } from './setup.js';
+
+describe.skipIf(!hasCredentials())('Task Reordering Operations (Integration)', () => {
+  let client: SunsamaClient;
+  const today = new Date().toISOString().split('T')[0]!;
+
+  beforeAll(async () => {
+    client = await getAuthenticatedClient();
+  });
+
+  describe('reorderTask', () => {
+    it('should move a task to the top of the day', async () => {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+      // Create two tasks scheduled for today
+      const taskIdA = SunsamaClient.generateTaskId();
+      const taskIdB = SunsamaClient.generateTaskId();
+      trackTaskForCleanup(taskIdA);
+      trackTaskForCleanup(taskIdB);
+
+      await client.createTask(`Test Reorder A - ${timestamp}`, {
+        taskId: taskIdA,
+        snoozeUntil: new Date(),
+      });
+      await client.createTask(`Test Reorder B - ${timestamp}`, {
+        taskId: taskIdB,
+        snoozeUntil: new Date(),
+      });
+
+      // Move B to position 0 (top)
+      const result = await client.reorderTask(taskIdB, 0, today);
+
+      expect(Array.isArray(result.updatedTaskIds)).toBe(true);
+      expect(result.updatedTaskIds.length).toBeGreaterThan(0);
+    });
+
+    it('should move a task to a middle position', async () => {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+      const taskIdA = SunsamaClient.generateTaskId();
+      const taskIdB = SunsamaClient.generateTaskId();
+      const taskIdC = SunsamaClient.generateTaskId();
+      trackTaskForCleanup(taskIdA);
+      trackTaskForCleanup(taskIdB);
+      trackTaskForCleanup(taskIdC);
+
+      await client.createTask(`Test Reorder Mid A - ${timestamp}`, {
+        taskId: taskIdA,
+        snoozeUntil: new Date(),
+      });
+      await client.createTask(`Test Reorder Mid B - ${timestamp}`, {
+        taskId: taskIdB,
+        snoozeUntil: new Date(),
+      });
+      await client.createTask(`Test Reorder Mid C - ${timestamp}`, {
+        taskId: taskIdC,
+        snoozeUntil: new Date(),
+      });
+
+      // Fetch sorted tasks to determine current positions, then move one to position 1
+      const tasks = await client.getTasksByDay(today);
+      const testTasks = tasks.filter(t => [taskIdA, taskIdB, taskIdC].includes(t._id));
+
+      if (testTasks.length >= 2) {
+        const result = await client.reorderTask(testTasks[0]!._id, 1, today);
+        expect(Array.isArray(result.updatedTaskIds)).toBe(true);
+      }
+    });
+
+    it('should support explicit timezone option', async () => {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+      const taskIdA = SunsamaClient.generateTaskId();
+      const taskIdB = SunsamaClient.generateTaskId();
+      trackTaskForCleanup(taskIdA);
+      trackTaskForCleanup(taskIdB);
+
+      await client.createTask(`Test Reorder TZ A - ${timestamp}`, {
+        taskId: taskIdA,
+        snoozeUntil: new Date(),
+      });
+      await client.createTask(`Test Reorder TZ B - ${timestamp}`, {
+        taskId: taskIdB,
+        snoozeUntil: new Date(),
+      });
+
+      const result = await client.reorderTask(taskIdA, 0, today, {
+        timezone: 'America/New_York',
+      });
+
+      expect(Array.isArray(result.updatedTaskIds)).toBe(true);
+    });
+
+    it('should return correct __typename', async () => {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+      const taskIdA = SunsamaClient.generateTaskId();
+      const taskIdB = SunsamaClient.generateTaskId();
+      trackTaskForCleanup(taskIdA);
+      trackTaskForCleanup(taskIdB);
+
+      await client.createTask(`Test Reorder Type A - ${timestamp}`, {
+        taskId: taskIdA,
+        snoozeUntil: new Date(),
+      });
+      await client.createTask(`Test Reorder Type B - ${timestamp}`, {
+        taskId: taskIdB,
+        snoozeUntil: new Date(),
+      });
+
+      const result = await client.reorderTask(taskIdA, 0, today);
+
+      expect(result.__typename).toBe('UpdateTasksBulkPayload');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up fixes for #26 (`reorderTask`) before publishing.

- **Error classes**: Replace misused `SunsamaAuthError` with the correct subclasses — `SunsamaValidationError` for invalid date/position inputs, `SunsamaError` for task-not-found and missing response data
- **Ordinal calculation**: Fix `calculateOrdinal` to avoid producing negative ordinals when moving a task to the top of a list whose first task has a small ordinal value (use midpoint toward zero instead of subtracting 1024)
- **Integration tests**: Add `tasks-reordering.test.ts` following the shared auth pattern
- **README**: Add `reorderTask` usage examples
- **CLAUDE.md**: Document error class selection guidelines and rebase merge preference

## Test plan
- [x] Unit tests pass (`pnpm test`)
- [ ] Integration tests pass (`pnpm test:integration`) — requires real credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ordinal calculation when reordering tasks to the top of a list to prevent negative ordinals.
  * Improved error handling with more specific error types: validation errors for invalid inputs and general errors for lookup failures.

* **Documentation**
  * Added comprehensive task reordering guidance including multiple usage examples and timezone support information.

* **Tests**
  * Added integration tests for task reordering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->