### PR TITLE
feat: add getTasksBacklogBucketed paginated backlog query

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ const tasksWithTz = await client.getTasksByDay('2025-01-15', 'America/New_York')
 // Get backlog tasks
 const backlog = await client.getTasksBacklog();
 
+// Get paginated backlog tasks (with cursor-based pagination)
+const backlogPage = await client.getTasksBacklogBucketed({ first: 10 });
+console.log('Tasks:', backlogPage.tasks.length);
+console.log('Has more:', backlogPage.pageInfo.hasNextPage);
+
+// Fetch next page
+if (backlogPage.pageInfo.hasNextPage) {
+  const nextPage = await client.getTasksBacklogBucketed({
+    first: 10,
+    after: backlogPage.pageInfo.endCursor,
+  });
+}
+
 // Get archived tasks with pagination
 const archivedTasks = await client.getArchivedTasks();
 const moreArchived = await client.getArchivedTasks(100, 50); // offset 100, limit 50

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -104,6 +104,40 @@ describe('SunsamaClient', () => {
       await expect(client.getTasksBacklog()).rejects.toThrow();
     });
 
+    it('should have getTasksBacklogBucketed method', () => {
+      const client = new SunsamaClient();
+
+      expect(typeof client.getTasksBacklogBucketed).toBe('function');
+    });
+
+    it('should throw error when calling getTasksBacklogBucketed without authentication', async () => {
+      const client = new SunsamaClient();
+
+      // Should fail because no authentication
+      await expect(client.getTasksBacklogBucketed()).rejects.toThrow();
+    });
+
+    it('should accept pagination options in getTasksBacklogBucketed', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+
+      // Should pass validation but fail at GraphQL level (unauthorized)
+      await expect(client.getTasksBacklogBucketed({ first: 10 })).rejects.toThrow(
+        'GraphQL errors: Unauthorized'
+      );
+      await expect(
+        client.getTasksBacklogBucketed({ first: 20, after: 'cursor123' })
+      ).rejects.toThrow('GraphQL errors: Unauthorized');
+    });
+
+    it('should use default first value in getTasksBacklogBucketed', async () => {
+      const client = new SunsamaClient({ sessionToken: 'test-token' });
+
+      // Should pass validation with defaults but fail at GraphQL level (unauthorized)
+      await expect(client.getTasksBacklogBucketed()).rejects.toThrow(
+        'GraphQL errors: Unauthorized'
+      );
+    });
+
     it('should have getStreamsByGroupId method', () => {
       const client = new SunsamaClient();
 

--- a/src/queries/tasks/queries.ts
+++ b/src/queries/tasks/queries.ts
@@ -61,6 +61,59 @@ export const GET_ARCHIVED_TASKS_QUERY = gql`
   ${TASK_INTEGRATION_FRAGMENT}
 `;
 
+/**
+ * Query for fetching backlog tasks with cursor-based pagination
+ *
+ * Variables:
+ * - userId: The user ID (required)
+ * - groupId: The group ID (required)
+ * - first: Number of tasks to fetch for forward pagination (optional)
+ * - after: Cursor for forward pagination (optional)
+ * - last: Number of tasks to fetch for backward pagination (optional)
+ * - before: Cursor for backward pagination (optional)
+ * - filter: Task filter object (optional)
+ */
+export const GET_TASKS_BACKLOG_BUCKETED_QUERY = gql`
+  query getTasksBacklogBucketed(
+    $userId: String!
+    $groupId: String!
+    $after: String
+    $before: String
+    $first: Int
+    $last: Int
+    $filter: TaskFilter
+  ) {
+    tasksBacklogBucketed(
+      userId: $userId
+      groupId: $groupId
+      after: $after
+      before: $before
+      first: $first
+      last: $last
+      filter: $filter
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+        __typename
+      }
+      tasks {
+        ...Task
+        __typename
+      }
+      __typename
+    }
+  }
+
+  ${TASK_FRAGMENT}
+
+  ${TASK_ACTUAL_TIME_FRAGMENT}
+
+  ${TASK_SCHEDULED_TIME_FRAGMENT}
+
+  ${TASK_INTEGRATION_FRAGMENT}
+`;
+
 export const GET_TASK_BY_ID_QUERY = gql`
   query getTaskById($taskId: String!, $groupId: String!) {
     taskById(taskId: $taskId, groupId: $groupId) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -886,6 +886,92 @@ export interface GetTasksBacklogResponse {
 }
 
 /**
+ * Filter for backlog bucketed query
+ */
+export interface TaskFilter {
+  [key: string]: unknown;
+}
+
+/**
+ * Options for getTasksBacklogBucketed method
+ */
+export interface GetTasksBacklogBucketedOptions {
+  /** Number of tasks to fetch (forward pagination). Defaults to 30. */
+  first?: number;
+
+  /** Cursor for forward pagination (fetch tasks after this cursor) */
+  after?: string;
+
+  /** Number of tasks to fetch (backward pagination) */
+  last?: number;
+
+  /** Cursor for backward pagination (fetch tasks before this cursor) */
+  before?: string;
+
+  /** Filter to apply to backlog tasks */
+  filter?: TaskFilter;
+}
+
+/**
+ * Input variables for getTasksBacklogBucketed query (internal GraphQL API)
+ */
+export interface GetTasksBacklogBucketedInput {
+  /** User ID */
+  userId: string;
+
+  /** Group ID */
+  groupId: string;
+
+  /** Number of tasks to fetch (forward pagination) */
+  first?: number;
+
+  /** Cursor for forward pagination */
+  after?: string;
+
+  /** Number of tasks to fetch (backward pagination) */
+  last?: number;
+
+  /** Cursor for backward pagination */
+  before?: string;
+
+  /** Filter to apply to backlog tasks */
+  filter?: TaskFilter;
+}
+
+/**
+ * Page info for cursor-based pagination
+ */
+export interface BacklogPageInfo {
+  /** Whether there are more pages after the current one */
+  hasNextPage: boolean;
+
+  /** Cursor for the last item in the current page */
+  endCursor: string | null;
+
+  __typename: 'BacklogPageInfo';
+}
+
+/**
+ * Result of getTasksBacklogBucketed query
+ */
+export interface TasksBacklogBucketedResult {
+  /** Pagination info */
+  pageInfo: BacklogPageInfo;
+
+  /** Array of backlog tasks */
+  tasks: Task[];
+
+  __typename: 'TasksBacklogBucketedResult';
+}
+
+/**
+ * Response for getTasksBacklogBucketed query
+ */
+export interface GetTasksBacklogBucketedResponse {
+  tasksBacklogBucketed: TasksBacklogBucketedResult;
+}
+
+/**
  * Stream standup rule structure
  */
 export interface StreamStandupRule {


### PR DESCRIPTION
## Summary
- Add `getTasksBacklogBucketed()` method — a cursor-based paginated version of `getTasksBacklog()` for efficiently fetching large backlogs
- Add full TypeScript types (`BacklogPageInfo`, `TasksBacklogBucketedResult`, pagination options)
- Add `GET_TASKS_BACKLOG_BUCKETED_QUERY` GraphQL query with `pageInfo` and cursor support (`after`/`before`/`first`/`last`/`filter`)

## Test plan
- [x] Unit tests: method existence, auth check, pagination options, default values (4 tests)
- [x] Integration tests: basic retrieval, custom page size, cursor pagination, task property validation (4 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (210 tests)
- [x] `pnpm lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination support for backlog task retrieval with customizable page sizes and filtering options.

* **Documentation**
  * Updated with pagination usage examples and best practices for handling page navigation.

* **Tests**
  * Added unit and integration test coverage for pagination functionality, including multi-page retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->