### PR TITLE
feat: add updateTasksBacklogFolder endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,13 @@ const folders = await client.getBacklogFolders();
 folders.forEach(folder => {
   console.log(folder.name, folder.position);
 });
+
+// Move tasks into a backlog folder
+const result = await client.updateTasksBacklogFolder(['taskId1', 'taskId2'], 'folderId');
+console.log('Updated tasks:', result.updatedTaskIds);
+
+// Remove tasks from their backlog folder
+await client.updateTasksBacklogFolder(['taskId1'], null);
 ```
 
 ### Streams

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -800,6 +800,19 @@ describe('SunsamaClient', () => {
       );
     });
 
+    it('should have updateTasksBacklogFolder method', () => {
+      const client = new SunsamaClient();
+
+      expect(typeof client.updateTasksBacklogFolder).toBe('function');
+    });
+
+    it('should throw error when calling updateTasksBacklogFolder without authentication', async () => {
+      const client = new SunsamaClient();
+
+      // Should fail because no authentication
+      await expect(client.updateTasksBacklogFolder(['test-task-id'], null)).rejects.toThrow();
+    });
+
     it('should have reorderTask method', () => {
       const client = new SunsamaClient();
 

--- a/src/__tests__/integration/backlog-folders.test.ts
+++ b/src/__tests__/integration/backlog-folders.test.ts
@@ -5,7 +5,7 @@
 import 'dotenv/config';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { SunsamaClient } from '../../client/index.js';
-import { getAuthenticatedClient, hasCredentials } from './setup.js';
+import { getAuthenticatedClient, hasCredentials, trackTaskForCleanup } from './setup.js';
 
 describe.skipIf(!hasCredentials())('Backlog Folder Operations (Integration)', () => {
   let client: SunsamaClient;
@@ -37,6 +37,59 @@ describe.skipIf(!hasCredentials())('Backlog Folder Operations (Integration)', ()
         expect(folder.lastModified).toBeDefined();
         expect(folder.__typename).toBe('BacklogFolder');
       }
+    });
+  });
+
+  describe('updateTasksBacklogFolder', () => {
+    it('should move a task into a backlog folder and back out', async () => {
+      const folders = await client.getBacklogFolders();
+      if (folders.length === 0) return;
+
+      const folder = folders[0]!;
+
+      // Create a task to use for this test
+      const taskId = SunsamaClient.generateTaskId();
+      trackTaskForCleanup(taskId);
+      await client.createTask('Test backlog folder assignment', { taskId });
+
+      // Move task to backlog first
+      await client.updateTaskSnoozeDate(taskId, null);
+
+      // Move task into the folder
+      const assignResult = await client.updateTasksBacklogFolder([taskId], folder._id);
+      expect(Array.isArray(assignResult.updatedTaskIds)).toBe(true);
+      expect(assignResult.updatedTaskIds).toContain(taskId);
+
+      // Remove task from folder
+      const removeResult = await client.updateTasksBacklogFolder([taskId], null);
+      expect(Array.isArray(removeResult.updatedTaskIds)).toBe(true);
+      expect(removeResult.updatedTaskIds).toContain(taskId);
+    });
+
+    it('should handle multiple task IDs', async () => {
+      const folders = await client.getBacklogFolders();
+      if (folders.length === 0) return;
+
+      const folder = folders[0]!;
+
+      // Create two tasks
+      const taskId1 = SunsamaClient.generateTaskId();
+      trackTaskForCleanup(taskId1);
+      await client.createTask('Test bulk folder 1', { taskId: taskId1 });
+
+      const taskId2 = SunsamaClient.generateTaskId();
+      trackTaskForCleanup(taskId2);
+      await client.createTask('Test bulk folder 2', { taskId: taskId2 });
+
+      // Move both to backlog
+      await client.updateTaskSnoozeDate(taskId1, null);
+      await client.updateTaskSnoozeDate(taskId2, null);
+
+      // Move both tasks into the folder
+      const result = await client.updateTasksBacklogFolder([taskId1, taskId2], folder._id);
+      expect(Array.isArray(result.updatedTaskIds)).toBe(true);
+      expect(result.updatedTaskIds).toContain(taskId1);
+      expect(result.updatedTaskIds).toContain(taskId2);
     });
   });
 });

--- a/src/queries/backlog-folders/index.ts
+++ b/src/queries/backlog-folders/index.ts
@@ -2,4 +2,5 @@
  * Backlog folder-related GraphQL operations exports
  */
 
+export * from './mutations.js';
 export * from './queries.js';

--- a/src/queries/backlog-folders/mutations.ts
+++ b/src/queries/backlog-folders/mutations.ts
@@ -1,0 +1,21 @@
+/**
+ * Backlog folder-related GraphQL mutations
+ */
+
+import { gql } from 'graphql-tag';
+
+/**
+ * Mutation for updating the backlog folder assignment for multiple tasks
+ *
+ * Variables:
+ * - input.taskIds: Array of task IDs to update
+ * - input.folderId: The folder ID to move tasks into, or null to remove from folder
+ */
+export const UPDATE_TASKS_BACKLOG_FOLDER_MUTATION = gql`
+  mutation updateTasksBacklogFolder($input: UpdateTasksBacklogFolderInput!) {
+    updateTasksBacklogFolder(input: $input) {
+      updatedTaskIds
+      __typename
+    }
+  }
+`;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1557,6 +1557,19 @@ export interface UpdateTaskSubtaskUncompleteInput {
 }
 
 /**
+ * Input for updateTasksBacklogFolder mutation
+ *
+ * Moves tasks into or out of a backlog folder.
+ */
+export interface UpdateTasksBacklogFolderInput {
+  /** Array of task IDs to update */
+  taskIds: string[];
+
+  /** The folder ID to move tasks into, or null to remove from folder */
+  folderId: string | null;
+}
+
+/**
  * Input for updateTaskMoveToPanel mutation
  *
  * Moves/reorders a task within a day panel.


### PR DESCRIPTION
## Summary
- Add `updateTasksBacklogFolder()` method to move tasks into or out of backlog folders
- Add `UpdateTasksBacklogFolderInput` type and GraphQL mutation
- Reuse existing `UpdateTasksBulkPayload` response type
- Add unit tests, integration tests, and README examples

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (210/210 tests, including 2 new unit tests)
- [x] `pnpm lint` passes
- [ ] Run `pnpm test:integration` to verify end-to-end with real API